### PR TITLE
Add check for exception message

### DIFF
--- a/Core/CallableExpectation.php
+++ b/Core/CallableExpectation.php
@@ -1,4 +1,5 @@
 <?hh //strict
+
 namespace HackPack\HackUnit\Core;
 
 class CallableExpectation
@@ -7,7 +8,7 @@ class CallableExpectation
     {
     }
 
-    public function toThrow(string $exceptionType): void
+    public function toThrow(string $exceptionType, ?string $expectedMessage = null): void
     {
         try {
             $fun = $this->context;
@@ -17,9 +18,18 @@ class CallableExpectation
                 $message = sprintf("%s was thrown in %s (%d).\n%s was expected.", get_class($e), $e->getFile(), $e->getLine(), $exceptionType);
                 throw new ExpectationException($message);
             }
+
+            if ($expectedMessage !== null && $expectedMessage != $e->getMessage()) {
+                $actualMessage = $e->getMessage();
+                $message = sprintf("Got message of %s, but %s was expected.", $actualMessage, $expectedMessage);
+                throw new ExpectationException($message);
+            }
+
             return;
         }
+
         throw new ExpectationException("No exception was thrown.\n$exceptionType was expected.");
+
     }
 
     public function toNotThrow(): void

--- a/Tests/Core/CallableExpectationTest.php
+++ b/Tests/Core/CallableExpectationTest.php
@@ -54,4 +54,20 @@ class CallableExpectationTest extends TestCase
             $this->expectCallable($fun)->toThrow('\HackPack\HackUnit\Core\ExpectationException');
         }
     }
+
+    public function test_toThrow_throws_exception_if_exception_thrown_with_incorrect_message(): void
+    {
+        $this->expectCallable(() ==> {
+            $callable = () ==> { throw new \HackPack\HackUnit\Core\ExpectationException("Message"); };
+            $expectation = new CallableExpectation($callable);
+            $expectation->toThrow('\\HackPack\HackUnit\Core\ExpectationException', 'Different Message');
+        })->toThrow('\HackPack\HackUnit\Core\ExpectationException');
+    }
+
+    public function test_toThrow_does_nothing_if_exception_thrown_with_correct_message(): void
+    {
+        $this->expectCallable(
+          () ==> {  throw new \HackPack\HackUnit\Core\ExpectationException("Message");
+        })->toThrow('\HackPack\HackUnit\Core\ExpectationException', 'Message');
+    }
 }


### PR DESCRIPTION
Allows for you to test your exception messages to ensure the exception has been flung at the right time.

Example

``` hack
public function testThrowsException():void 
{
        $this->expectCallable(
                () ==> {  throw new \HackPack\HackUnit\Core\ExpectationException("Message");
        })->toThrow('\HackPack\HackUnit\Core\ExpectationException', 'Message');
}
```
