### PR TITLE
Add more information to report when a test fails.

### DIFF
--- a/Core/Expectation.php
+++ b/Core/Expectation.php
@@ -16,8 +16,12 @@ class Expectation<T>
     {
         $equals = $this->getContext() == $comparison;
         if (!$equals) {
-            $message = sprintf('Expected %s, got %s', $comparison, $this->getContext());
-            throw new ExpectationException($message); 
+            $message = sprintf(
+                "Actual:\n%sExpected:\n%s",
+                $this->captureVarDump($this->getContext()),
+                $this->captureVarDump($comparison),
+            );
+            throw new ExpectationException($message);
         }
     }
 
@@ -28,5 +32,12 @@ class Expectation<T>
             $message = sprintf('Expected %s to match pattern "%s"', $this->getContext(), $pattern);
             throw new ExpectationException($message);
         }
+    }
+
+    private function captureVarDump(mixed $var) : string
+    {
+        ob_start();
+        trim(implode("\n    ", explode("\n", var_dump($var))));
+        return '    ' . ob_get_clean();
     }
 }

--- a/Runner/Loading/Instantiator.php
+++ b/Runner/Loading/Instantiator.php
@@ -7,7 +7,7 @@ class Instantiator
     const int T_STRING = 307;
     const int T_CLASS = 353;
 
-    private static Map<string, string> $pathMap = Map {}; 
+    private static Map<string, string> $pathMap = Map {};
 
     public function fromClassName<T>(string $className, array<mixed> $args): T
     {

--- a/Tests/Core/CallableExpectationTest.php
+++ b/Tests/Core/CallableExpectationTest.php
@@ -46,7 +46,7 @@ class CallableExpectationTest extends TestCase
         $expectation = new CallableExpectation($callable);
         $expectation->toNotThrow();
     }
-    
+
     public function test_toNotThrow_throws_exception_if_exception_thrown(): void
     {
         if ($this->callable) {

--- a/Tests/Core/ExpectationTest.php
+++ b/Tests/Core/ExpectationTest.php
@@ -34,8 +34,8 @@ class ExpectationTest extends TestCase
             $expectation = new Expectation("hello");
             $expectation->toMatch('/^he/');
         })->toNotThrow();
-    }   
-   
+    }
+
     public function test_toMatch_throws_ExpectationException_if_fails(): void
     {
         $this->expectCallable(() ==> {


### PR DESCRIPTION
I was somewhat frustrated at the lack of information when my tests were failing, so I added some data to the reports.

The simple expectation class now prints a var_dump of the expected and actual values.

The callable expectation class now shows the expected exception class name, the actual exception class name (or lack of one) as well as the file and line it was actually thrown.
