### PR TITLE
Add assertion for instanceOf

### DIFF
--- a/Core/Expectation.php
+++ b/Core/Expectation.php
@@ -40,4 +40,19 @@ class Expectation<T>
         trim(implode("\n    ", explode("\n", var_dump($var))));
         return '    ' . ob_get_clean();
     }
+
+    public function toBeInstanceOf(string $expectedClassName): void
+    {
+      if (!is_object($this->context)) {
+          $type = gettype($this->context);
+          $message = sprintf("Got a %s value, expected to get an instance of '%s'.", $type, $expectedClassName);
+          throw new ExpectationException($message);
+      }
+
+      if (!is_a($this->context, $expectedClassName)) {
+        $instanceClassName = get_class($this->context);
+        $message = sprintf("Got an instance of '%s', expected to get an instance of '%s'.", $expectedClassName, $instanceClassName);
+        throw new ExpectationException($message);
+      }
+    }
 }

--- a/Tests/Core/ExpectationTest.php
+++ b/Tests/Core/ExpectationTest.php
@@ -44,4 +44,29 @@ class ExpectationTest extends TestCase
         })->toThrow('\HackPack\HackUnit\Core\ExpectationException');
     }
 
+    public function test_toBeInstanceOf_does_not_throw_exception_when_match(): void
+    {
+        $instance = new Expectation("string here");
+        $this->expectCallable(() ==> {
+            $expectation = new Expectation($instance);
+            $expectation->toBeInstanceOf('\HackPack\HackUnit\Core\Expectation');
+        })->toNotThrow();
+    }
+
+    public function test_toBeInstanceOf_does_throw_exception_when_does_not_match(): void
+    {
+        $instance = new Expectation("string here");
+        $this->expectCallable(() ==> {
+            $expectation = new Expectation($instance);
+            $expectation->toBeInstanceOf('\HackPack\HackUnit\Core\TestCase');
+        })->toThrow('\HackPack\HackUnit\Core\ExpectationException');
+    }
+
+    public function test_toBeInstanceOf_does_throw_exception_when_not_class(): void
+    {
+        $this->expectCallable(() ==> {
+            $expectation = new Expectation("string here");
+            $expectation->toBeInstanceOf('\HackPack\HackUnit\Core\TestCase');
+        })->toThrow('\HackPack\HackUnit\Core\ExpectationException');
+    }
 }


### PR DESCRIPTION
Added a method to do an assertion that an object is an instance of a class.

Example

```
public function testIsInstance(): void {
   $instance = -new FancyClass();
   $this->expect($instance)->toBeInstanceOf(FancyClass');
}
```
