### PR TITLE
Once the class name is found, stop looking for it.

### DIFF
--- a/Runner/Loading/Instantiator.php
+++ b/Runner/Loading/Instantiator.php
@@ -55,9 +55,14 @@ class Instantiator
                 if ($tokens[$i][0] === Instantiator::T_CLASS) {
                     for ($j = $i + 1; $j < count($tokens); $j++) {
                         if ($tokens[$j] === '{') {
-                            $class = $tokens[$i +2][1];
+                            $class = $tokens[$i + 2][1];
+                            break;
                         }
                     }
+                }
+                if($class) {
+                    // Stop looking for the class name after it is found
+                    break;
                 }
             }
         }

--- a/Tests/Fixtures/Instantiating/MultipleClassTokenTest.php
+++ b/Tests/Fixtures/Instantiating/MultipleClassTokenTest.php
@@ -1,0 +1,11 @@
+<?hh // strict
+
+use HackPack\HackUnit\Core\TestCase;
+
+class MultipleClassTokenTest extends TestCase
+{
+    public function testHasClassToken() : void
+    {
+        MultipleClassTokenTest::class;
+    }
+}

--- a/Tests/Runner/Loading/InstantiatorTest.php
+++ b/Tests/Runner/Loading/InstantiatorTest.php
@@ -1,0 +1,21 @@
+<?hh // strict
+namespace HackPack\HackUnit\Tests\Runner\Loading;
+
+use HackPack\HackUnit\Core\TestCase;
+use HackPack\HackUnit\Runner\Loading\Instantiator;
+use \MultipleClassTokenTest;
+
+class InstantiatorTest extends TestCase
+{
+    public function test_fromFile_creates_object_from_file_with_multiple_class_tokens(): void
+    {
+        $filename = dirname(dirname(__DIR__)) . '/Fixtures/Instantiating/MultipleClassTokenTest.php';
+        /* HH_FIXME[1002] */
+        include_once($filename);
+        $instantiator = new Instantiator();
+        $this->expectCallable(() ==> {
+            $object = $instantiator->fromFile($filename, [MultipleClassTokenTest::class]);
+            $this->expect(get_class($object))->toEqual(MultipleClassTokenTest::class);
+        })->toNotThrow();
+    }
+}


### PR DESCRIPTION
It is possible for two `class` tokens to be in the 512 byte block that is searched.  This would happen if a test case is checking for class names.

This came up for me when I was making a type-safe strict mode IOCContainer.  I wanted to make sure the name of the class instantiated is as expected, and I used `ClassName::class` to get the name of the expected class as a string.  The parser interprets this as a `class` token.

The symptom was the loader was attempting to load a class with the correct namespace, but the class name was an empty string.
