### PR TITLE
Protect against non-existent paths

### DIFF
--- a/Runner/Loading/StandardLoader.php
+++ b/Runner/Loading/StandardLoader.php
@@ -79,6 +79,11 @@ use HackPack\HackUnit\Runner\Options;
     protected function isExcluded(string $path): bool
     {
         $real = realpath($path);
+
+        // realpath returns false when the path does not exist
+        if($real === false) {
+            return true;
+        }
         return $this->exclude->contains($real);
     }
 

--- a/Tests/Runner/Loading/StandardLoaderTest.php
+++ b/Tests/Runner/Loading/StandardLoaderTest.php
@@ -58,7 +58,7 @@ class StandardLoaderTest extends TestCase
         $this->expect($threeTest->getName())->toEqual('testFive');
         $this->expect($threeTest2->getName())->toEqual('testSix');
     }
-    
+
     public function test_loadSuite_should_use_results_of_load_to_create_a_TestSuite(): void
     {
         if (! $this->loader) throw new \Exception("loader cannot be null");
@@ -76,5 +76,15 @@ class StandardLoaderTest extends TestCase
         $loader = StandardLoader::create($options);
         $paths = $loader->getTestCasePaths();
         $this->expect($paths->count())->toEqual(2);
+    }
+
+    public function test_getTestCasePaths_should_exclude_nonexistent_dirs(): void
+    {
+        $options = new Options();
+        $options
+            ->setTestPath($this->path . '/DoesNotExist');
+        $loader = StandardLoader::create($options);
+        $paths = $loader->getTestCasePaths();
+        $this->expect($paths->count())->toEqual(0);
     }
 }


### PR DESCRIPTION
I ran into this problem when I accidentally put the wrong path name for my tests in my IOC Factory Container project.

Seems like a really small fix, and I'm not sure how to directly test it.
