### PR TITLE
Add expectation on outputed contents to CallableExpectation

### DIFF
--- a/Core/CallableExpectation.php
+++ b/Core/CallableExpectation.php
@@ -62,4 +62,32 @@ class CallableExpectation
             throw new ExpectationException($message);
         }
     }
+
+    public function toOutputString(string $expectedOutput): void
+    {
+        $fun = $this->context;
+
+        while (ob_get_level() > 0) {
+            ob_end_clean();
+        }
+        ob_start();
+        $obLevel = ob_get_level();
+
+        $fun();
+
+        if (ob_get_level() != $obLevel) {
+            while (ob_get_level() > 0) {
+                ob_end_clean();
+            }
+
+            $message = 'Test code or tested code did not (only) close its own output buffers';
+            throw new ExpectationException($message);
+        }
+
+        $actualOutput = ob_get_contents();
+        ob_end_clean();
+
+        $expectation = new Expectation($actualOutput);
+        $expectation->toEqual($expectedOutput);
+    }
 }

--- a/Tests/Core/CallableExpectationTest.php
+++ b/Tests/Core/CallableExpectationTest.php
@@ -70,4 +70,31 @@ class CallableExpectationTest extends TestCase
           () ==> {  throw new \HackPack\HackUnit\Core\ExpectationException("Message");
         })->toThrow('\HackPack\HackUnit\Core\ExpectationException', 'Message');
     }
+
+    public function test_toOutputString_does_nothing_when_true(): void
+    {
+        $this->expectCallable(() ==> {
+            $callable = () ==> { echo "an output string"; };
+            $expectation = new CallableExpectation($callable);
+            $expectation->toOutputString("an output string");
+        })->toNotThrow();
+    }
+
+    public function test_toOutputString_throws_ExpectationException_if_fails(): void
+    {
+        $this->expectCallable(() ==> {
+            $callable = () ==> { echo "an output string"; };
+            $expectation = new CallableExpectation($callable);
+            $expectation->toOutputString("something different");
+        })->toThrow('\HackPack\HackUnit\Core\ExpectationException');
+    }
+
+    public function test_toOutputString_throws_ExpectationException_if_ob_was_closed(): void
+    {
+        $this->expectCallable(() ==> {
+            $callable = () ==> { echo "an output string"; ob_end_clean(); };
+            $expectation = new CallableExpectation($callable);
+            $expectation->toOutputString("an output string");
+        })->toThrow('\HackPack\HackUnit\Core\ExpectationException');
+    }
 }


### PR DESCRIPTION
This commit adds a "toOutputString" method to CallableExpection, allowing
to make expectations on outputed contents.

The implementation uses the ob_* API to capture output and Expectation::toEqual
to compare the actual output with what was expected.