### PR TITLE
Replace the test loading system (#26)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "hhvm": "*",
         "kilahm/clio": "*",
-        "hackpack/hack-class-scanner": "^2.0"
+        "fredemmott/definition-finder": "^0.3.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Issue #26 

definition finder throws HH\InvariantException for a lot of tests. I will start to write tests for my project and update HackUnit tests and will see what is causing it.
I had a problem with my project that I had a namespace ending with Attribute (Symfony\Component\HttpFoundation\Session\Attribute) and the definition finder threw the Exception because Attribute token is reserved by XHP.