### PR TITLE
Add jUnit report formatter

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -107,4 +107,19 @@ final class Assert implements Contract\Assert {
       $l($skip);
     }
   }
+
+  public function fail(string $message): void {
+    $stack = Util\Trace::generate();
+    $traceItem = shape(
+      'file' => $stack[0]['file'],
+      'line' => $stack[0]['line'],
+      'function' => $stack[1]['function'],
+      'class' => $stack[1]['class'],
+    );
+    $fail =
+      new Event\Failure($message, $traceItem, Util\Trace::findTestMethod());
+    foreach ($this->failureListeners as $l) {
+      $l($fail);
+    }
+  }
 }

--- a/src/Contract/Assert.php
+++ b/src/Contract/Assert.php
@@ -16,8 +16,9 @@ interface Assert {
   public function container<T>(
     Container<T> $context,
   ): Assertion\ContainerAssertion<T>;
-  public function keyedContainer<Tkey,Tval>(
-    KeyedContainer<Tkey,Tval> $context,
-  ): Assertion\KeyedContainerAssertion<Tkey,Tval>;
+  public function keyedContainer<Tkey, Tval>(
+    KeyedContainer<Tkey, Tval> $context,
+  ): Assertion\KeyedContainerAssertion<Tkey, Tval>;
   public function skip(string $reason, ?TraceItem $traceItem = null): void;
+  public function fail(string $reason): void;
 }

--- a/src/Report/Format/JUnit.php
+++ b/src/Report/Format/JUnit.php
@@ -1,0 +1,77 @@
+<?hh // strict
+
+namespace HackPack\HackUnit\Report\Format;
+
+use HackPack\HackUnit\Report\Format;
+use HackPack\HackUnit\Report\Summary;
+use HackPack\HackUnit\Report\TestResult;
+use HackPack\HackUnit\Report\TestSummary;
+use HackPack\HackUnit\Report\SuiteSummary;
+use SimpleXMLElement;
+
+final class JUnit implements Format {
+  private SimpleXMLElement $report;
+
+  public static function build(string $reportPath): this {
+    return new self(fopen($reportPath, 'w'));
+  }
+
+  public function __construct(private resource $out) {
+    $this->report = new SimpleXMLElement('<testsuites/>');
+  }
+  public function writeReport(Summary $summary): void {
+    foreach ($summary['suite summaries'] as $name => $suiteSummary) {
+      $this->report->addChild('testsuite')
+        |> $this->populateSuiteReport($name, $suiteSummary, $$);
+    }
+    fwrite($this->out, $this->report->asXML());
+  }
+
+  private function populateSuiteReport(
+    string $name,
+    SuiteSummary $summary,
+    SimpleXMLElement $report,
+  ): void {
+    $report->addAttribute('name', $name);
+    $this->addSuiteCounts($summary, $report);
+    foreach ($summary['test summaries'] as $testName => $testSummary) {
+      $report->addChild('testcase')
+        |> $this->populateTestReport($name, $testName, $testSummary, $$);
+    }
+  }
+
+  private function addSuiteCounts(
+    SuiteSummary $summary,
+    SimpleXMLElement $report,
+  ): void {
+    $report->addAttribute('failures', $summary['fail count']);
+    $report->addAttribute('tests', $summary['test count']);
+  }
+
+  private function populateTestReport(
+    string $suiteName,
+    string $name,
+    TestSummary $summary,
+    SimpleXMLElement $report,
+  ): void {
+    $report->addAttribute('name', $name);
+    $report->addAttribute('classname', $suiteName);
+
+    switch ($summary['result']) {
+      case TestResult::Pass:
+      case TestResult::Error:
+        // Error is not used yet
+        // Nothing more to add when test passes
+        break;
+      case TestResult::Fail:
+        $event = $summary['fail event'];
+        $message = $event === null ? 'Unknown failure' : $event->getMessage();
+        $failElement = $report->addChild('failure');
+        $failElement->addAttribute('message', $message);
+        break;
+      case TestResult::Skip:
+        $report->addChild('skip');
+        break;
+    }
+  }
+}

--- a/test/Report/JUnit.php
+++ b/test/Report/JUnit.php
@@ -1,0 +1,232 @@
+<?hh // strict
+/*
+ junit.rnc:
+ #----------------------------------------------------------------------------------
+ start = testsuite
+ property = element property {
+ attribute name {text},
+ attribute value {text}
+ }
+ properties = element properties {
+ property*
+ }
+ failure = element failure {
+ attribute message {text},
+ attribute type {text},
+ text
+ }
+ testcase = element testcase {
+ attribute classname {text},
+ attribute name {text},
+ attribute time {text},
+ failure?
+ }
+ testsuite = element testsuite {
+ attribute errors {xsd:integer},
+ attribute failures {xsd:integer},
+ attribute hostname {text},
+ attribute name {text},
+ attribute tests {xsd:integer},
+ attribute time {xsd:double},
+ attribute timestamp {xsd:dateTime},
+ properties,
+ testcase*,
+ element system-out {text},
+ element system-err {text}
+ }
+ #----------------------------------------------------------------------------------
+ and junitreport.rnc
+ #----------------------------------------------------------------------------------
+ include "junit.rnc" {
+ start = testsuites
+ testsuite = element testsuite {
+ attribute errors {xsd:integer},
+ attribute failures {xsd:integer},
+ attribute hostname {text},
+ attribute name {text},
+ attribute tests {xsd:integer},
+ attribute time {xsd:double},
+ attribute timestamp {xsd:dateTime},
+ attribute id {text},
+ attribute package {text},
+ properties,
+ testcase*,
+ element system-out {text},
+ element system-err {text}
+ }
+ }
+ testsuites = element testsuites {
+ testsuite*
+ }
+ */
+
+namespace HackPack\HackUnit\Tests\Report;
+
+use HackPack\HackUnit\Event\Failure;
+use HackPack\HackUnit\Report\Format\JUnit;
+use HackPack\HackUnit\Report\TestResult;
+use HackPack\HackUnit\Report\Summary;
+use HackPack\HackUnit\Report\SummaryBuilder;
+use HackPack\HackUnit\Contract\Assert;
+use SimpleXMLElement;
+
+class JUnitTest {
+
+  private resource $stream;
+  private JUnit $formatter;
+  private Summary $summary;
+
+  public function __construct() {
+    $this->stream = fopen('php://memory', 'r+');
+    $this->formatter = new JUnit($this->stream);
+    $this->summary = SummaryBuilder::emptySummary();
+  }
+
+  <<Test>>
+  public function rootNodeIsCreated(Assert $assert): void {
+    $this->formatter->writeReport($this->summary);
+    $report = $this->getActualReport($assert);
+    $assert->string($report->getName())->is('testsuites');
+    $attributeCount = 0;
+    foreach ($report->attributes() as $name => $value) {
+      $attributeCount++;
+    }
+    $assert->int($attributeCount)->eq(0);
+  }
+
+  <<Test>>
+  public function suiteReportsAreGenerated(Assert $assert): void {
+    $this->summary['suite summaries'] = Map {
+      'suite 1' => SummaryBuilder::emptySuiteSummary(),
+      'suite 2' => SummaryBuilder::emptySuiteSummary(),
+    };
+
+    $this->formatter->writeReport($this->summary);
+    $report = $this->getActualReport($assert);
+    $assert->int(count($report->xpath('testsuite')))->eq(2);
+  }
+
+  <<Test>>
+  public function executionTimeIsIncludedInSuiteReport(Assert $assert): void {
+    $assert->skip('Need to time individual suites');
+  }
+
+  <<Test>>
+  public function suiteNameIsIncluded(Assert $assert): void {
+    $suiteSummary = SummaryBuilder::emptySuiteSummary();
+    $this->summary['suite summaries'] = Map {'suite name' => $suiteSummary};
+    $this->formatter->writeReport($this->summary);
+    $report = $this->getActualReport($assert)->xpath('testsuite')[0];
+    $assert->string((string) $report['name'])->is('suite name');
+  }
+
+  <<Test>>
+  public function suiteCountsAreIncluded(Assert $assert): void {
+    $suiteSummary = SummaryBuilder::emptySuiteSummary();
+    $suiteSummary['fail count'] = 2;
+    $suiteSummary['test count'] = 5;
+    $this->summary['suite summaries'] = Map {'suite name' => $suiteSummary};
+
+    $this->formatter->writeReport($this->summary);
+    $report = $this->getActualReport($assert)->xpath('testsuite')[0];
+
+    $assert->string((string) $report->offsetGet('failures'))->is('2');
+    $assert->string((string) $report->offsetGet('tests'))->is('5');
+  }
+
+  <<Test>>
+  public function testsAreIncluded(Assert $assert): void {
+    $suiteSummary = SummaryBuilder::emptySuiteSummary();
+    $suiteSummary['test summaries'] = Map {
+      'test1' => SummaryBuilder::emptyTestSummary(),
+      'test2' => SummaryBuilder::emptyTestSummary(),
+    };
+    $this->summary['suite summaries'] = Map {'suite name' => $suiteSummary};
+    $this->formatter->writeReport($this->summary);
+    $report = $this->getActualReport($assert)->xpath('testsuite')[0];
+
+    $testCases = $report->xpath('testcase');
+    $assert->int(count($testCases))->eq(2);
+  }
+
+  <<Test>>
+  public function timingIsIncludedInTestReports(Assert $assert): void {
+    $assert->skip('Need to time individual tests.');
+  }
+
+  <<Test>>
+  public function testNameIsIncluded(Assert $assert): void {
+    $suiteSummary = SummaryBuilder::emptySuiteSummary();
+    $suiteSummary['test summaries'] = Map {
+      'test name' => SummaryBuilder::emptyTestSummary(),
+    };
+
+    $summary = SummaryBuilder::emptySummary();
+    $summary['suite summaries'] = Map {'suite name' => $suiteSummary};
+
+    $this->formatter->writeReport($summary);
+    $report = $this->getActualReport($assert);
+    $testReport = $report->xpath('/testsuites/testsuite/testcase')[0];
+
+    $assert->string((string) $testReport->offsetGet('name'))->is('test name');
+  }
+
+  <<Test>>
+  public function testFailureIsIncluded(Assert $assert): void {
+
+    $failEvent = Failure::fromCallStack('For jUnit report.');
+    $testSummary = SummaryBuilder::emptyTestSummary();
+    $testSummary['result'] = TestResult::Fail;
+    $testSummary['fail event'] = $failEvent;
+
+    $suiteSummary = SummaryBuilder::emptySuiteSummary();
+    $suiteSummary['test summaries'] = Map {'test name' => $testSummary};
+
+    $summary = SummaryBuilder::emptySummary();
+    $summary['suite summaries'] = Map {'suite name' => $suiteSummary};
+
+    $this->formatter->writeReport($summary);
+    $report = $this->getActualReport($assert);
+    $failElements = $report->xpath('/testsuites/testsuite/testcase/failure');
+    $assert->int(count($failElements))->eq(1);
+
+    $failure = $failElements[0];
+    $assert->string((string) $failure->offsetGet('message'))
+      ->is($failEvent->getMessage());
+  }
+
+  <<Test>>
+  public function testSkipIsIncluded(Assert $assert): void {
+    $testSummary = SummaryBuilder::emptyTestSummary();
+    $testSummary['result'] = TestResult::Skip;
+
+    $suiteSummary = SummaryBuilder::emptySuiteSummary();
+    $suiteSummary['test summaries'] = Map {'test name' => $testSummary};
+
+    $summary = SummaryBuilder::emptySummary();
+    $summary['suite summaries'] = Map {'suite name' => $suiteSummary};
+
+    $this->formatter->writeReport($summary);
+    $report = $this->getActualReport($assert);
+    $failElements = $report->xpath('/testsuites/testsuite/testcase/skip');
+    $assert->int(count($failElements))->eq(1);
+  }
+
+  private function getActualReport(Assert $assert): SimpleXMLElement {
+    rewind($this->stream);
+    $rawXml = stream_get_contents($this->stream);
+    try {
+      $report = new SimpleXMLElement($rawXml);
+    } catch (\Exception $e) {
+      $assert->fail(
+        sprintf(
+          "XML error: %s\nOriginal XML:\n%s",
+          $e->getMessage(),
+          $rawXml,
+        ),
+      );
+      throw new \RuntimeException('This should not be reached');
+    }
+    return $report;
+  }
+}

--- a/test/self-test.php
+++ b/test/self-test.php
@@ -18,10 +18,13 @@ require_once $root.'/vendor/autoload.php';
 $reportFormatters = Vector {new CliFormat(STDOUT)};
 
 // CircleCI provides this env
-// $circleReportDir = getenv('CIRCLE_TEST_REPORTS');
-// if (is_string($circleReportDir)) {
-//   $reportFormatters->add(JUnitFormat::build($circleReportDir.'/report.xml'));
-// }
+$circleReportDir = getenv('CIRCLE_TEST_REPORTS');
+if (is_string($circleReportDir)) {
+  echo
+    PHP_EOL.'jUnit report will be saved to '.$circleReportDir.'/report.xml'
+  ;
+  $reportFormatters->add(JUnitFormat::build($circleReportDir.'/report.xml'));
+}
 $status = new Status(STDOUT);
 
 $suiteBuilder = new SuiteBuilder(


### PR DESCRIPTION
* Generate a jUnit report for self-test on CircleCI.

TODO: store timing data for suites and tests in the summary.