### PR TITLE
Fixed type error in HHVM 3.23.1

### DIFF
--- a/src/Report/SummaryBuilder.php
+++ b/src/Report/SummaryBuilder.php
@@ -64,6 +64,7 @@ type SuiteSummary = shape(
 type TestSummary = shape(
   'assert count' => int,
   'success count' => int,
+  'test count' => int,
   'result' => TestResult,
   'skip event' => ?Skip,
   'fail event' => ?Failure,
@@ -240,7 +241,9 @@ class SummaryBuilder {
     return shape(
       'assert count' => 0,
       'success count' => 0,
-      'message' => '',
+      'test count' => 0,
+      'skip event' => null,
+      'fail event' => null,
       'result' => TestResult::Pass,
     );
   }


### PR DESCRIPTION
A type error occurred in HHVM 3.23.1, so it was fixed.
Since the Docker container can be pulled with CircleCI, I do not know if I pass the test.

```shell
ubuntu@ubuntu-xenial:~/_hackunit$ hh_client check
HackUnit/src/Report/SummaryBuilder.php:240:12,16: Invalid return type (Typing[4166])
  HackUnit/src/Report/SummaryBuilder.php:239:46,56: The field 'message' is not defined in this shape type, and this shape type does not allow unknown fields.
  HackUnit/src/Report/SummaryBuilder.php:240:12,16: The field 'message' is set in the shape.
HackUnit/test/Report/SummaryBuilder.php:135:54,69: Invalid argument (Typing[4166])
  HackUnit/src/Report/SummaryBuilder.php:61:41,51: The field 'test count' is not defined in this shape type, and this shape type does not allow unknown fields.
  HackUnit/test/Report/SummaryBuilder.php:118:5,47: The field 'test count' is set in the shape.
```